### PR TITLE
fix(release): make wallaby run right out of the box

### DIFF
--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "../out-tsc/spec",
     "baseUrl": "./",
-    d
     "types": [
       "jest",
       "node"

--- a/wallaby.js
+++ b/wallaby.js
@@ -22,7 +22,7 @@ module.exports = function (wallaby) {
     preprocessors: {
       // This translate templateUrl and styleUrls to the right implementation
       // For wallaby
-      'projects/**/*.component.ts': ngxWallabyJest,
+      'src/app/**/*.component.ts': ngxWallabyJest,
     },
     testFramework: 'jest'
   };


### PR DESCRIPTION
the `wallaby.js` configuration pointed to the wrong folder to search for the application's components